### PR TITLE
The SystemAverageLoad is -1.0 on windows platforms

### DIFF
--- a/src/clj/matthiasn/systems_toolbox_metrics/metrics.clj
+++ b/src/clj/matthiasn/systems_toolbox_metrics/metrics.clj
@@ -15,7 +15,7 @@
 (defn system-utilization
   []
   (let [^MemoryUsage mem-usage (.getHeapMemoryUsage mem-mx-bean)]
-    {:system-load-avg (.getSystemLoadAverage os-mx-bean)
+    {:system-load-avg (max 0 (.getSystemLoadAverage os-mx-bean))
      :available-cpus  (.getAvailableProcessors os-mx-bean)
      :heap-used       (.getUsed mem-usage)
      :heap-max        (.getMax mem-usage)


### PR DESCRIPTION
Hi, Matthias:

I'm trying to write a web app with your system-toolbox, which is very cool and teach me a lot.

But I found there's a problem of system-toolbox-metrics on win platform, please see the screenshot as below:

![ss](https://cloud.githubusercontent.com/assets/5813426/15680885/d0bf53e2-2789-11e6-8d8a-16765538e0de.png)

So, please review my changes.

BTW, I'm a Clojure newbie. :-P
